### PR TITLE
Update runner.html

### DIFF
--- a/spec/runner.html
+++ b/spec/runner.html
@@ -8,11 +8,11 @@
 		<div id="mocha"></div>
 
 		<script src="../node_modules/mocha/mocha.js"></script>
-		<!--
-		<script src="../node_modules/blanket/dist/qunit/blanket.js" data-cover-only="BaseViewModel"></script>
-		<script src="../node_modules/blanket/src/adapters/mocha-blanket.js"></script>
-		-->
 		<script src="../source/components/requirejs/require.js"></script>
+		<!-- blanket script references, this need to be placed after mocha and require -->
+		<script src="../node_modules/blanket/dist/qunit/blanket.js" data-cover-only="source/BaseViewModel"></script>
+		<script src="../node_modules/blanket/src/adapters/mocha-blanket.js"></script>
+		
 		<script>
 			mocha.setup("bdd");
 			require(["../source/config"], function (config) {


### PR DESCRIPTION
Updated the placement of the blanket script reference, and made the data-cover-only attribute more specific.

Coverage should work after this.

As for the messy header, that's a bug in the Blanket mocha adapter.  The adapter is causing the mocha runner to be run twice, which is causing a DOM artifact.  I'm going to update the mocha adapter in the blanket repo, and then you can `npm update` or manually copy the change into your repo.
